### PR TITLE
fix: use parsed yaml to populate yaml variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,8 @@ class ServerlessStepFunctionsLocal {
 
     const configPath = path.join(servicePath, 'serverless.yml');
 
-    const parsed = await this.serverless.yamlParser.parse(configPath);
+    const preParsed = await this.serverless.yamlParser.parse(configPath);
+    const parsed = await this.serverless.variables.populateObject(preParsed);
 
     this.stateMachines = parsed.stepFunctions.stateMachines;
 


### PR DESCRIPTION
there's some occasions where the State Machine is in another file. Example:

```yaml
stepFunctions:
  stateMachines:
    WaitMachine: ${file(src/mystatemachine.yml)}
```

currently, that variable is not resolved

with the line added, the variable will now be resolved and populate the object
