### PR TITLE
Fixes stage being ignored when set in provider

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ class ServerlessStepFunctionsLocal {
     this.log = serverless.cli.log.bind(serverless.cli);
     this.config = (this.service.custom && this.service.custom.stepFunctionsLocal) || {};
     
-    if (this.service.provider.stage !== undefined) {
+    if (this.service.provider !== undefined && this.service.provider.stage !== undefined) {
       this.stage = this.service.provider.stage;
     } else if (this.service.stage !== undefined) {
       this.stage = this.service.stage;

--- a/index.js
+++ b/index.js
@@ -12,9 +12,17 @@ class ServerlessStepFunctionsLocal {
 
     this.log = serverless.cli.log.bind(serverless.cli);
     this.config = (this.service.custom && this.service.custom.stepFunctionsLocal) || {};
+    
+    if (this.service.provider.stage !== undefined) {
+      this.stage = this.service.provider.stage;
+    } else if (this.service.stage !== undefined) {
+      this.stage = this.service.stage;
+    } else {
+      this.stage = 'dev';
+    }
 
     // Check config
-    if (!this.config.accountId) {
+    if (this.config.accountId === undefined) {
       throw new Error('Step Functions Local: missing accountId');
     }
 
@@ -214,7 +222,7 @@ class ServerlessStepFunctionsLocal {
       switch (state.Type) {
         case 'Task':
           if (state.Resource && state.Resource['Fn::GetAtt'] && Array.isArray(state.Resource['Fn::GetAtt'])) {
-            state.Resource = `arn:aws:lambda:${this.config.region}:${this.config.accountId}:function:${this.service.service}-${this.serverless.stage ? this.serverless.stage : 'dev'}-${state.Resource['Fn::GetAtt'][0]}`
+            state.Resource = `arn:aws:lambda:${this.config.region}:${this.config.accountId}:function:${this.service.service}-${this.stage}-${state.Resource['Fn::GetAtt'][0]}`
           }
           break;
         case 'Map':

--- a/index.js
+++ b/index.js
@@ -12,11 +12,11 @@ class ServerlessStepFunctionsLocal {
 
     this.log = serverless.cli.log.bind(serverless.cli);
     this.config = (this.service.custom && this.service.custom.stepFunctionsLocal) || {};
-    
-    if (this.service.provider !== undefined && this.service.provider.stage !== undefined) {
-      this.stage = this.service.provider.stage;
-    } else if (this.service.stage !== undefined) {
+
+    if (this.service.stage !== undefined) {
       this.stage = this.service.stage;
+    } else if (this.service.provider !== undefined && this.service.provider.stage !== undefined) {
+      this.stage = this.service.provider.stage;
     } else {
       this.stage = 'dev';
     }


### PR DESCRIPTION
Had some problems when using a stage name "development".

Upon investigating I noticed the plugin reads the stage value from `service.stage`; but it seems the value should be read from `service.provider.stage`. I've fixed the code in a backwards compatible way, making it so the stage name will be read in this order:

* service.provider.stage
* service.stage
* fallback to "dev" as it was.


Additionally changed the accountId check to verify against undefined instead of a simple negation, so accounts Ids like `000000000` won't be rejected. 