### PR TITLE
Use of ConfigurationInput to retrieve Step Functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ class ServerlessStepFunctionsLocal {
 
         const bootstrap = (async () => {
           await this.startStepFunctions();
-          await this.getStepFunctionsFromConfig();
+          await this.getStepFunctionsFromConfigurationInput();
           await this.createEndpoints();
         })()
 
@@ -103,25 +103,16 @@ class ServerlessStepFunctionsLocal {
     return this.stepfunctionsServer.stop();
   }
 
-  async getStepFunctionsFromConfig() {
-    const {servicePath} = this.serverless.config;
+  async getStepFunctionsFromConfigurationInput() {
 
-    if (!servicePath) {
-      throw new Error('service path not found');
+    this.stateMachines = this.stateMachineCFARNResolver(this.serverless.configurationInput.stepFunctions.stateMachines);
+
+    if (this.serverless.configurationInput.custom
+      && this.serverless.configurationInput.custom.stepFunctionsLocal
+      && this.serverless.configurationInput.custom.stepFunctionsLocal.TaskResourceMapping) {
+        this.replaceTaskResourceMappings(this.serverless.configurationInput.stepFunctions.stateMachines, this.serverless.configurationInput.custom.stepFunctionsLocal.TaskResourceMapping);
     }
 
-    const configPath = path.join(servicePath, 'serverless.yml');
-
-    const preParsed = await this.serverless.yamlParser.parse(configPath);
-    const parsed = await this.serverless.variables.populateObject(preParsed);
-
-    this.stateMachines = this.stateMachineCFARNResolver(parsed.stepFunctions.stateMachines);
-
-    if (parsed.custom
-      && parsed.custom.stepFunctionsLocal
-      && parsed.custom.stepFunctionsLocal.TaskResourceMapping) {
-        this.replaceTaskResourceMappings(parsed.stepFunctions.stateMachines, parsed.custom.stepFunctionsLocal.TaskResourceMapping);
-    }
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -104,15 +104,17 @@ class ServerlessStepFunctionsLocal {
   }
 
   async getStepFunctionsFromConfigurationInput() {
-
     this.stateMachines = this.stateMachineCFARNResolver(this.serverless.configurationInput.stepFunctions.stateMachines);
 
     if (this.serverless.configurationInput.custom
       && this.serverless.configurationInput.custom.stepFunctionsLocal
-      && this.serverless.configurationInput.custom.stepFunctionsLocal.TaskResourceMapping) {
-        this.replaceTaskResourceMappings(this.serverless.configurationInput.stepFunctions.stateMachines, this.serverless.configurationInput.custom.stepFunctionsLocal.TaskResourceMapping);
+      && this.serverless.configurationInput.custom.stepFunctionsLocal.TaskResourceMapping
+    ) {
+        this.replaceTaskResourceMappings(
+          this.serverless.configurationInput.stepFunctions.stateMachines,
+          this.serverless.configurationInput.custom.stepFunctionsLocal.TaskResourceMapping
+        );
     }
-
   }
 
   /**


### PR DESCRIPTION
Hello,
I noticed the plugin was crashing when using Serverless frameworkVersion 3 (using 3.25.1)

The change I am proposing is to retrieve the step functions from the Serverless configuration input instead of parsing the config with YAMLParser.

Now starting Serverless version 3 creates the step functions locally as expected.